### PR TITLE
Get rid of internal use of DataPointPen

### DIFF
--- a/Lib/fontPens/flattenPen.py
+++ b/Lib/fontPens/flattenPen.py
@@ -100,12 +100,12 @@ def flattenGlyph(aGlyph, threshold=10, segmentLines=True):
     if len(aGlyph) == 0:
         return aGlyph
     from ufoLib.pointPen import SegmentToPointPen
-    from fontPens.dataPointPen import DataPointPen
-    data = DataPointPen()
-    filterpen = FlattenPen(SegmentToPointPen(data), approximateSegmentLength=threshold, segmentLines=segmentLines)
+    from fontTools.pens.recordingPen import RecordingPen
+    recorder = RecordingPen()
+    filterpen = FlattenPen(recorder, approximateSegmentLength=threshold, segmentLines=segmentLines)
     aGlyph.draw(filterpen)
     aGlyph.clear()
-    data.draw(aGlyph.getPen())
+    recorder.replay(aGlyph.getPen())
     return aGlyph
 
 

--- a/Lib/fontPens/thresholdPen.py
+++ b/Lib/fontPens/thresholdPen.py
@@ -50,12 +50,12 @@ def thresholdGlyph(aGlyph, threshold=10):
     Convenience function that applies the **ThresholdPen** to a glyph. Returns a new glyph object (from objectsRF.RGlyph).
     """
     from ufoLib.pointPen import SegmentToPointPen
-    from fontPens.dataPointPen import DataPointPen
-    data = DataPointPen()
-    filterpen = ThresholdPen(SegmentToPointPen(data), threshold)
+    from fontTools.pens.recordingPen import RecordingPen
+    recorder = RecordingPen()
+    filterpen = ThresholdPen(recorder, threshold)
     aGlyph.draw(filterpen)
     aGlyph.clear()
-    data.draw(aGlyph.getPen())
+    recorder.replay(aGlyph.getPen())
     return aGlyph
 
 


### PR DESCRIPTION
fontTools.pens.recordingPen is more appropriate in these two cases anyway. Probably didn't exist yet at the time.