### PR TITLE
Travis-ci: added support for ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,15 @@ matrix:
       env: TOXENV=py37-cov
     - python: 3.8
       env: TOXENV=py38-cov
+    - python: 3.6
+      env: TOXENV=py36-cov
+      arch: ppc64le
+    - python: 3.7
+      env: TOXENV=py37-cov
+      arch: ppc64le
+    - python: 3.8
+      env: TOXENV=py38-cov
+      arch: ppc64le
     - python: pypy3
       env: TOXENV=pypy3
     - language: generic
@@ -42,6 +51,7 @@ cache:
     - $HOME/.pyenv_cache
 
 before_install:
+  - if [ "$TRAVIS_ARCH" = "ppc64le" ]; then sudo chown -Rv $USER:$GROUP ~/.cache/pip/wheels; fi
   - source ./.travis/before_install.sh
 
 install:


### PR DESCRIPTION
Hi,
I have added support for ppc64le build on travis-ci in the branch . The travis-ci build log can be tracked on the link :https://travis-ci.com/github/sanjaymsh/fontPens/builds/190104499 . I believe it is ready for the final review and merge.
Please have a look on it and if everything looks fine for you then please approve it for merge.

Thanks !!