### PR TITLE
Add publish job to the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-latest
 
     # Specifying a GitHub environment is optional, but strongly encouraged
-    environment: pypi
+    environment: publish-to-pypi
     permissions:
       # IMPORTANT: this permission is mandatory for Trusted Publishing
       id-token: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
     # only run if the commit is tagged...
     if: startsWith(github.ref, 'refs/tags/v')
     # ... and the test job completed successfully
-    needs: [test]
+    needs: [pre-commit, test]
     runs-on: ubuntu-latest
 
     # Specifying a GitHub environment is optional, but strongly encouraged

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,3 +46,73 @@ jobs:
     - name: Test with pytest
       run: |
         pytest -v
+
+  publish:
+    # only run if the commit is tagged...
+    if: startsWith(github.ref, 'refs/tags/v')
+    # ... and the test job completed successfully
+    needs: [test]
+    runs-on: ubuntu-latest
+
+    # Specifying a GitHub environment is optional, but strongly encouraged
+    environment: pypi
+    permissions:
+      # IMPORTANT: this permission is mandatory for Trusted Publishing
+      id-token: write
+      contents: write
+
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: "3.x"
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install --upgrade build
+
+    - name: Build wheel and source distro
+      run: |
+        python -m build
+
+    - name: Extract release notes from annotated tag message
+      id: release_notes
+      env:
+        # e.g. v0.1.0a1, v1.2.0b2 or v2.3.0rc3, but not v1.0.0
+        PRERELEASE_TAG_PATTERN: "v[[:digit:]]+\\.[[:digit:]]+\\.[[:digit:]]+([ab]|rc)[[:digit:]]+"
+      run: |
+        # GH checkout action doesn't preserve tag annotations, we must fetch them
+        # https://github.com/actions/checkout/issues/290
+        git fetch --tags --force
+        # strip leading 'refs/tags/' to get the tag name
+        TAG_NAME="${GITHUB_REF##*/}"
+        # Dump tag message to temporary .md file (excluding the PGP signature at the bottom)
+        TAG_MESSAGE=$(git tag -l --format='%(contents)' $TAG_NAME | sed -n '/-----BEGIN PGP SIGNATURE-----/q;p')
+        echo "$TAG_MESSAGE" > "${{ runner.temp }}/release_notes.md"
+        # if the tag has a pre-release suffix mark the Github Release accordingly
+        if egrep -q "$PRERELEASE_TAG_PATTERN" <<< "$TAG_NAME"; then
+          echo "Tag contains a pre-release suffix"
+          echo "IS_PRERELEASE=true" >> "$GITHUB_ENV"
+        else
+          echo "Tag does not contain pre-release suffix"
+          echo "IS_PRERELEASE=false" >> "$GITHUB_ENV"
+        fi
+
+    - name: Publish distributions to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+
+    - name: Create GitHub release
+      id: create_release
+      uses: actions/create-release@v2
+      env:
+        # This token is provided by Actions, you do not need to create your own token
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: ${{ github.ref }}
+        body_path: "${{ runner.temp }}/release_notes.md"
+        draft: false
+        prerelease: ${{ env.IS_PRERELEASE }}

--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,9 @@ Lib/fontPens.egg-info/
 # PyCharm's directory
 .idea/
 
+# virtual environment
+venv
+.venv
+
 # vcs
 Lib/fontPens/_version.py


### PR DESCRIPTION
This still requires setting up Trusted Publishing on the PyPI side. If you add me as a maintainer I will do that.

The (GH) release notes will be set via the message of an annotated tag. I'll update the README with instructions if you agree with this approach. (This is an ongoing struggle for me, I don't really know what the "best practice" way of doing release notes is. I chose this way because the project doesn't have a CHANGELOG.md file.)